### PR TITLE
Raise demo-repo approval count to 2 per our policy

### DIFF
--- a/repos-dpritchett-test.tf
+++ b/repos-dpritchett-test.tf
@@ -24,7 +24,7 @@ resource "github_branch_protection" "protect-demo-repo-master" {
   enforce_admins = true
 
   required_pull_request_reviews {
-    required_approving_review_count = 1
+    required_approving_review_count = 2
     dismiss_stale_reviews           = true
   }
 


### PR DESCRIPTION
Hey Daniel. Here's a PR raising the number of required approvals for master from 1 to 2 per our policy. It looks like this one branch was overlooked the last time we checked these. Please merge and apply this terraform change to sort it out.