### PR TITLE
Allow developers team to push to cool-hacks repo

### DIFF
--- a/repos-dpritchett-test.tf
+++ b/repos-dpritchett-test.tf
@@ -46,5 +46,5 @@ resource "github_team_repository" "dpritchett-test_team_repository_cool-hacks" {
 
   team_id    = "${github_team.dpritchett-test-developers.id}"
   repository = "${github_repository.dpritchett-test_repo_cool-hacks.name}"
-  permission = "pull"
+  permission = "push"
 }


### PR DESCRIPTION
Hey Daniel. I need to push a change to the cool-hacks repo but it looks like [Bob changed it to be read-only last month](https://github.com/dpritchett/repo-config-management/commit/a341dc6ea6aac50f4ba3ed0cbcbb841873e1532b#diff-3e5901b644f5b87b5564571c2809e254R49).

Can you please merge and apply this PR to make it writeable again? Thanks!

